### PR TITLE
Updated Project Paths Location & fixed package.json dependencies

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,8 +38,8 @@
     "main": "./out/src/extension",
     "contributes": {
         "configuration": {
-            "type": "object",
-            "title": "Crane Configuration",
+        "type": "object",
+        "title": "Crane Configuration",
             "properties": {
                 "crane.showStatusBarBugReportLink": {
                     "type": "boolean",
@@ -101,7 +101,10 @@
         "vscode": "^0.11.13"
     },
     "dependencies": {
-        "vscode-languageclient": "^1.1.0",
-        "php-parser": "glayzzle/php-parser#6131b11"
+        "fstream": "^1.0.9",
+        "mkdirp": "^0.5.1",
+        "php-parser": "glayzzle/php-parser#6131b11",
+        "unzip": "^0.1.11",
+        "vscode-languageclient": "^1.1.0"
     }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -38,8 +38,8 @@
     "main": "./out/src/extension",
     "contributes": {
         "configuration": {
-        "type": "object",
-        "title": "Crane Configuration",
+            "type": "object",
+            "title": "Crane Configuration",
             "properties": {
                 "crane.showStatusBarBugReportLink": {
                     "type": "boolean",


### PR DESCRIPTION
I forgot to add some dependencies that were needed in a previous push to the `package.json`.

This will fix the error that gets displayed saying that the package(s) were not found.

I also added a new package (`mkdirp`) that will create a directory recursively similar to `mkdir -p`. This allowed me to remove some logic to make directory creation simpler.

I also made it so projects are created in `Crane/projects`, just so the `Crane` directory doesn't get cluttered.