### PR TITLE
Improved suggestions

### DIFF
--- a/server/src/hvy/treeBuilder.ts
+++ b/server/src/hvy/treeBuilder.ts
@@ -126,7 +126,7 @@ export class TreeBuilder
                     break;
 
                 case "const":
-                    // this fixes exception when trying ot get completion on file `use` statements
+                    // this fixes exception when trying to get completion on file `use` statements
                     if (branch[1][0] === undefined || branch[1][0][1] === undefined || branch[1][0][1][0] === undefined) {
                         break;
                     }

--- a/server/src/hvy/treeBuilder.ts
+++ b/server/src/hvy/treeBuilder.ts
@@ -126,6 +126,10 @@ export class TreeBuilder
                     break;
 
                 case "const":
+                    // this fixes exception when trying ot get completion on file `use` statements
+                    if (branch[1][0] === undefined || branch[1][0][1] === undefined || branch[1][0][1][0] === undefined) {
+                        break;
+                    }
                     let constantNode: ConstantNode = new ConstantNode();
                     if (Array.isArray(branch[1][0]) && Array.isArray(branch[1][0][1])) {
                         constantNode.name = branch[1][0][0];

--- a/server/src/suggestionBuilder.ts
+++ b/server/src/suggestionBuilder.ts
@@ -278,24 +278,55 @@ export class SuggestionBuilder
         this.workspaceTree.forEach(fileNode => {
             if (options.classes) {
                 fileNode.classes.forEach(item => {
-                    toReturn.push({ label: item.name, kind: CompletionItemKind.Class, detail: "(class)" });
+                    toReturn.push({
+                        label: item.name,
+                        kind: CompletionItemKind.Class,
+                        detail: '\\' + item.namespaceParts.join('\\'),
+                        insertText:
+                            (this.doc.getText().indexOf('use ' + item.namespaceParts.join('\\') + '\\' + item.name + ';') !== -1) ?
+                                item.name : item.namespaceParts.join('\\') + '\\' + item.name
+                    });
                 });
             }
 
             if (options.interfaces) {
                 fileNode.interfaces.forEach(item => {
-                    toReturn.push({ label: item.name, kind: CompletionItemKind.Interface, detail: "(interface)" });
+                    toReturn.push({
+                        label: item.name,
+                        kind: CompletionItemKind.Interface,
+                        detail: '\\' + item.namespace.join('\\'),
+                        insertText:
+                            (this.doc.getText().indexOf('use ' + item.namespace.join('\\') + '\\' + item.name + ';') !== -1) ?
+                                item.name : item.namespace.join('\\') + '\\' + item.name
+                    });
                 });
             }
 
             if (options.traits) {
                 fileNode.traits.forEach(item => {
-                    toReturn.push({ label: item.name, kind: CompletionItemKind.Module, detail: "(trait)" });
+                    toReturn.push({
+                        label: item.name,
+                        kind: CompletionItemKind.Module,
+                        detail: '\\' + item.namespaceParts.join('\\'),
+                        insertText:
+                            (this.doc.getText().indexOf('use ' + item.namespaceParts.join('\\') + '\\' + item.name + ';') !== -1) ?
+                                item.name : item.namespaceParts.join('\\') + '\\' + item.name
+                    });
                 });
             }
         });
 
-        return toReturn;
+        return toReturn.filter((item) => {
+            if (this.currentLine.indexOf('new') !== -1 || this.currentLine.indexOf('extends') !== -1 && (this.currentLine.indexOf('extends') < this.charIndex)) {
+                return item.kind === CompletionItemKind.Class;
+            }
+
+            if (this.currentLine.indexOf('implements') !== -1 && (this.currentLine.indexOf('implements') < this.charIndex)) {
+                return item.kind === CompletionItemKind.Interface;
+            }
+
+            return true;
+        });
     }
 
     private getScope() : Scope

--- a/server/src/suggestionBuilder.ts
+++ b/server/src/suggestionBuilder.ts
@@ -284,7 +284,9 @@ export class SuggestionBuilder
                         detail: '\\' + item.namespaceParts.join('\\'),
                         insertText:
                             (this.doc.getText().indexOf('use ' + item.namespaceParts.join('\\') + '\\' + item.name + ';') !== -1) ?
-                                item.name : item.namespaceParts.join('\\') + '\\' + item.name
+                                item.name : (item.namespaceParts.length > 0 ? (
+                                    this.currentLine.indexOf('use ') !== 0 ? '\\' : ''
+                                ) + item.namespaceParts.join('\\') : '') + '\\'+ item.name
                     });
                 });
             }
@@ -297,7 +299,9 @@ export class SuggestionBuilder
                         detail: '\\' + item.namespace.join('\\'),
                         insertText:
                             (this.doc.getText().indexOf('use ' + item.namespace.join('\\') + '\\' + item.name + ';') !== -1) ?
-                                item.name : item.namespace.join('\\') + '\\' + item.name
+                                item.name : (item.namespace.length > 0 ? (
+                                    this.currentLine.indexOf('use ') !== 0 ? '\\' : ''
+                                ) + item.namespace.join('\\') : '') + '\\'+ item.name
                     });
                 });
             }
@@ -310,20 +314,34 @@ export class SuggestionBuilder
                         detail: '\\' + item.namespaceParts.join('\\'),
                         insertText:
                             (this.doc.getText().indexOf('use ' + item.namespaceParts.join('\\') + '\\' + item.name + ';') !== -1) ?
-                                item.name : item.namespaceParts.join('\\') + '\\' + item.name
+                                item.name : (item.namespaceParts.length > 0 ? (
+                                    this.currentLine.indexOf('use ') !== 0 ? '\\' : ''
+                                ) + item.namespaceParts.join('\\') : '') + '\\'+ item.name
                     });
                 });
             }
         });
 
         return toReturn.filter((item) => {
-            if (this.currentLine.indexOf('new') !== -1 || this.currentLine.indexOf('extends') !== -1 && (this.currentLine.indexOf('extends') < this.charIndex)) {
+            if (this.currentLine.indexOf(' new ') !== -1 || this.currentLine.indexOf(' extends ') !== -1 && (this.currentLine.indexOf(' extends ') < this.charIndex)) {
                 return item.kind === CompletionItemKind.Class;
             }
 
-            if (this.currentLine.indexOf('implements') !== -1 && (this.currentLine.indexOf('implements') < this.charIndex)) {
+            if (this.currentLine.indexOf(' implements ') !== -1 && (this.currentLine.indexOf(' implements ') < this.charIndex)) {
                 return item.kind === CompletionItemKind.Interface;
             }
+
+            if (this.currentLine.indexOf(' use ') === 0) {
+                return item.kind === CompletionItemKind.Module;
+            }
+
+            /**
+             * This prevents issues where suggestions hould be there but are not
+             * like when assigning the result of a static method call to a variable,
+             * looking for '=' on the line is a bit risky and might lead to poor
+             * suggestions, also another case is when typehinting the function/method
+             * arguments.
+             */
 
             return true;
         });

--- a/server/src/suggestionBuilder.ts
+++ b/server/src/suggestionBuilder.ts
@@ -296,12 +296,12 @@ export class SuggestionBuilder
                     toReturn.push({
                         label: item.name,
                         kind: CompletionItemKind.Interface,
-                        detail: '\\' + item.namespace.join('\\'),
+                        detail: '\\' + item.namespaceParts.join('\\'),
                         insertText:
-                            (this.doc.getText().indexOf('use ' + item.namespace.join('\\') + '\\' + item.name + ';') !== -1) ?
-                                item.name : (item.namespace.length > 0 ? (
+                            (this.doc.getText().indexOf('use ' + item.namespaceParts.join('\\') + '\\' + item.name + ';') !== -1) ?
+                                item.name : (item.namespaceParts.length > 0 ? (
                                     this.currentLine.indexOf('use ') !== 0 ? '\\' : ''
-                                ) + item.namespace.join('\\') : '') + '\\'+ item.name
+                                ) + item.namespaceParts.join('\\') : '') + '\\'+ item.name
                     });
                 });
             }


### PR DESCRIPTION
Updated [my previous PR #195](https://github.com/HvyIndustries/crane/pull/195) PR against `develop` instead of `master` (too quick on the buttons)

   - Insert the FQN instead of just the class/interface/trait names, this solves the problem where one might forget to add use statement (this is particularly useful for me, since I don't always remember the exact FQN or know the FQN of a library I am using or generally makes my life easier not hyaving to think what it was)

   - Filter suggestions based on keywords present on the current line, for example suggest only classes when new is found, or suggest only interfaces when when there is implements before the cursor on the current line, same goes for extends as well, but here it checks if the cursor is after extends, but before implements (they cannot be switched, language-enforced limitation)

   - Change suggestions' `insertText` based on, whether or not the current class/interface/trait is imported in the file, if it is, insert just the name, otherwise push the FQN.

I will be happy to review any issues that are present in the code, so please let me know if something does not fit/might be done better or anything that can be done as well

P.S I am kinda new to writing code extensions, so keep it in mind :)