### PR TITLE
Adding showStatusBarIcon config

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,11 @@
                     "default": true,
                     "description": "Show or hide the status bar item asking you to report any PHP Intellisense bugs"
                 },
+                "crane.showStatusBarIcon": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show or hide the status bar item with the version"
+                },
                 "crane.enableCache": {
                     "type": "boolean",
                     "default": true,

--- a/client/src/crane.ts
+++ b/client/src/crane.ts
@@ -106,7 +106,10 @@ export default class Crane
         var statusBarItem: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
         statusBarItem.text = Config.version;
         statusBarItem.tooltip = 'Crane (PHP Code-completion) version ' + Config.version;
-        statusBarItem.show();
+
+        if (Config.showStatusBarIcon){
+            statusBarItem.show();
+        }
 
         var serverDebugMessage: NotificationType<{ type: string, message: string }> = { method: "serverDebugMessage" };
         Crane.langClient.onNotification(serverDebugMessage, message => {

--- a/client/src/utils/Config.ts
+++ b/client/src/utils/Config.ts
@@ -26,6 +26,11 @@ export class Config {
         return Config.craneSettings ? Config.craneSettings.get<boolean>("showStatusBarBugReportLink", true) : true;
     }
 
+    public static get showStatusBarIcon(): boolean {
+        Config.reloadConfig();
+        return Config.craneSettings ? Config.craneSettings.get<boolean>("showStatusBarIcon", true) : true;
+    }
+
     public static get phpstubsZipFile(): string {
         Config.reloadConfig();
         return Config.craneSettings ? Config.craneSettings.get<string>("phpstubsZipFile", "https://codeload.github.com/HvyIndustries/crane-php-stubs/zip/master") : "https://codeload.github.com/HvyIndustries/crane-php-stubs/zip/master";


### PR DESCRIPTION
Added new configuration `showStatusBarIcon`. Now for real (I started from `master` and not `develop`, it was a mess)

- Hide the status bar icon with the version, unless showBugReport was enabled
- Default value: `true`, to keep backward compatibility.

Relevant issue: https://github.com/HvyIndustries/crane/issues/357